### PR TITLE
Fix GitHub build by replacing deprecated node12 Lua action

### DIFF
--- a/.github/workflows/lua.yml
+++ b/.github/workflows/lua.yml
@@ -6,19 +6,24 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: leafo/gh-actions-lua@v5
-      with:
-        luaVersion: "5.1"
+    - uses: actions/checkout@v4
+    - name: Install Lua 5.1
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y lua5.1
+        sudo ln -sf /usr/bin/luac5.1 /usr/local/bin/luac
+        luac -v
     - name: lua-releng
       run: wget --quiet --output-document - https://github.com/openresty/openresty-devel-utils/raw/master/lua-releng 2>/dev/null | perl
 
   compile:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: leafo/gh-actions-lua@v5
-      with:
-        luaVersion: luajit
+    - uses: actions/checkout@v4
+    - name: Install LuaJIT
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y luajit
+        luajit -v
     - name: luajit
       run: find $(pwd) -name "*.lua" -type f -exec luajit -bl {} > /dev/null \;

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Oversample
 
 ![Build][build-badge]
+![License][license-badge]
 
 Oversample is a [Renoise][renoise] plugin that will increase all quality
 parameters (such as "oversampling", "quality", "phase", etc.) in all active
@@ -30,3 +31,4 @@ needs and may not work for you.**
 
   [renoise]: https://www.renoise.com/
   [build-badge]: https://github.com/asbjornu/org.bitbear.Oversample.xrnx/actions/workflows/lua.yml/badge.svg
+  [license-badge]: https://img.shields.io/github/license/asbjornu/org.bitbear.Oversample.xrnx

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![Build][build-badge]
 ![License][license-badge]
 ![Renoise API][renoise-api-badge]
+![Lua][lua-badge]
 
 Oversample is a [Renoise][renoise] plugin that will increase all quality
 parameters (such as "oversampling", "quality", "phase", etc.) in all active
@@ -34,3 +35,4 @@ needs and may not work for you.**
   [build-badge]: https://github.com/asbjornu/org.bitbear.Oversample.xrnx/actions/workflows/lua.yml/badge.svg
   [license-badge]: https://img.shields.io/github/license/asbjornu/org.bitbear.Oversample.xrnx
   [renoise-api-badge]: https://img.shields.io/badge/Renoise%20API-6-blue
+  [lua-badge]: https://img.shields.io/badge/Lua-5.1-blue

--- a/README.md
+++ b/README.md
@@ -29,4 +29,4 @@ needs and may not work for you.**
   keep backups.
 
   [renoise]: https://www.renoise.com/
-  [build-badge]: https://github.com/asbjornu/org.bitbear.Oversample.xrnx/workflows/Build/badge.svg
+  [build-badge]: https://github.com/asbjornu/org.bitbear.Oversample.xrnx/actions/workflows/lua.yml/badge.svg

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ![Build][build-badge]
 ![License][license-badge]
+![Renoise API][renoise-api-badge]
 
 Oversample is a [Renoise][renoise] plugin that will increase all quality
 parameters (such as "oversampling", "quality", "phase", etc.) in all active
@@ -32,3 +33,4 @@ needs and may not work for you.**
   [renoise]: https://www.renoise.com/
   [build-badge]: https://github.com/asbjornu/org.bitbear.Oversample.xrnx/actions/workflows/lua.yml/badge.svg
   [license-badge]: https://img.shields.io/github/license/asbjornu/org.bitbear.Oversample.xrnx
+  [renoise-api-badge]: https://img.shields.io/badge/Renoise%20API-6-blue


### PR DESCRIPTION
The `leafo/gh-actions-lua@v5` action uses the removed node12 runtime, causing both the lint and compile jobs to fail before running any Lua checks. Install Lua 5.1 and LuaJIT directly via apt instead.

Also add a bunch of badges to the readme while we're at it.